### PR TITLE
add String/UniqueName

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ foreach ($period as $one) {
 
 - ZeroableInterface
 
+## String Utility
+
+- UniqueName
+
 # Support
 
 If you find a bug or have a question, or want to request a feature, create an issue or pull request for it on [Issues](https://github.com/phpmentors-jp/domain-commons/issues).

--- a/src/String/UniqueName.php
+++ b/src/String/UniqueName.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * Copyright (c) 2015 GOTO Hidenori <hidenorigoto@gmail.com>,
+ * All rights reserved.
+ *
+ * This file is part of Domain Commons.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\DomainCommons\String;
+
+/**
+ * @since Class available since Release 1.1.1
+ */
+class UniqueName
+{
+    /**
+     * @var array
+     */
+    private $source;
+    /**
+     * @var string
+     */
+    private $numberingPattern;
+    /**
+     * @var string
+     */
+    private $numberingPatternRexex;
+    private $numberingPatternExtractRegex;
+
+    public function __construct($source, $numberingPattern = ' (n)')
+    {
+        $this->source = $source;
+        $this->numberingPattern = $numberingPattern;
+        $this->numberingPatternRegex = sprintf('/(%s)$/',
+            str_replace('n', '\d+', preg_quote($this->numberingPattern)));
+        $this->numberingPatternExtractRegex = sprintf('/#BASE#(%s)$/',
+            str_replace('n', '(\d+)', preg_quote($this->numberingPattern)));
+    }
+
+    public function __invoke($name, $alreadyInSource = true)
+    {
+        $sameList = array_filter($this->source, function ($targetName) use ($name) {
+            return $targetName === $name;
+        });
+        if (count($sameList) <= ($alreadyInSource ? 1 : 0)) {
+            return $name;
+        }
+
+        $baseName = preg_replace($this->numberingPatternRegex, '', $name);
+
+        $matchedList = array_filter($this->source, function($targetName) use ($baseName) {
+            return strpos($targetName, $baseName) !== false;
+        });
+
+        $max = 0;
+        $regex = str_replace('#BASE#', $baseName, $this->numberingPatternExtractRegex);
+        foreach ($matchedList as $targetName) {
+            if (preg_match($regex, $targetName, $match)) {
+                $max = max($max, $match[2]);
+            }
+        }
+
+        return $baseName . $this->makeNumber($max + 1);
+    }
+
+    private function makeNumber($number)
+    {
+        return str_replace('n', $number, $this->numberingPattern);
+    }
+}

--- a/tests/String/UniqueNameTest.php
+++ b/tests/String/UniqueNameTest.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright (c) 2015 GOTO Hidenori <hidenorigoto@gmail.com>,
+ * All rights reserved.
+ *
+ * This file is part of Domain Commons.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\DomainCommons\String;
+
+/**
+ * @since Class available since Release 1.1.1
+ */
+class UniqueNameTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $list = [
+            'test1','test2','apple banana','test1 (1)','test2 (3)','php',''
+        ];
+        $uniqueName = new UniqueName($list);
+        $result = $uniqueName('test1');
+        $this->assertThat($result, $this->equalTo('test1'));
+        $result = $uniqueName('test1', false);
+        $this->assertThat($result, $this->equalTo('test1 (2)'));
+        $result = $uniqueName('test2 (2)');
+        $this->assertThat($result, $this->equalTo('test2 (2)'));
+
+
+        $list = [
+            'test1','test1',
+        ];
+        $uniqueName = new UniqueName($list);
+        $result = $uniqueName('test1');
+        $this->assertThat($result, $this->equalTo('test1 (1)'));
+        $result = $uniqueName('test1', false);
+        $this->assertThat($result, $this->equalTo('test1 (1)'));
+
+
+        $list = [
+            'test1','test1 (1)',
+        ];
+        $uniqueName = new UniqueName($list);
+        $result = $uniqueName('test1', false);
+        $this->assertThat($result, $this->equalTo('test1 (2)'));
+    }
+}


### PR DESCRIPTION
`String\UniqueName` provides a feature to make unique name against specified source list.

``` php
$source = ['test1','test2'];
$uniqueName = new UniqueName($source);
$newName = $uniqueName('test1', false);
echo $newName; // test1 (1)
```
