### PR TITLE
Update the minimum supported PHP version from 5.5 to 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /php-cs-fixer.phar
 /vendor/
 cache.properties
+.php_cs.cache
+.phpunit.result.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,10 +1,14 @@
 <?php
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
     ;
 
-return Symfony\CS\Config\Config::create()
-    ->fixers(array('-empty_return', '-blankline_after_open_tag', 'ordered_use', '-phpdoc_no_empty_return'))
-    ->finder($finder)
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        'blank_line_after_opening_tag' => true,
+        'phpdoc_no_empty_return' => true,
+    ])
+    ->setFinder($finder)
     ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,10 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.5
-  - 5.6
-  - 7
-  - 7.1
+  - 7.2
+  - 7.3
 
 matrix:
-  allow_failures:
-    - php: hhvm
   fast_finish: true
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.2",
         "phpmentors/domain-kata": "~1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.6"
+        "phpunit/phpunit": "~8.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,17 @@
-<phpunit bootstrap="tests/bootstrap.php">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         failOnRisky="true"
+         failOnWarning="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="Dommain Commons Test Suite">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-
-    <logging>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
-    </logging>
-
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
     <filter>
         <whitelist>
             <directory suffix=".php">src</directory>

--- a/tests/DateTime/AgeRangeTest.php
+++ b/tests/DateTime/AgeRangeTest.php
@@ -12,10 +12,12 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @since Class available since Release 1.1.0
  */
-class AgeRangeTest extends \PHPUnit_Framework_TestCase
+class AgeRangeTest extends TestCase
 {
     /**
      * @param string $target
@@ -47,7 +49,7 @@ class AgeRangeTest extends \PHPUnit_Framework_TestCase
      */
     public function getMaxAsDate(\DateTimeInterface $currentDate, $max, $maxAsDate)
     {
-        $clock = $this->getMock('PHPMentors\DomainCommons\DateTime\Clock');
+        $clock = $this->createMock('PHPMentors\DomainCommons\DateTime\Clock');
         $clock->method('now')->will($this->returnValue($currentDate));
         $ageRange = new AgeRange();
         $ageRange->setClock($clock);
@@ -76,7 +78,7 @@ class AgeRangeTest extends \PHPUnit_Framework_TestCase
      */
     public function getMinAsDate(\DateTimeInterface $currentDate, $min, $minAsDate)
     {
-        $clock = $this->getMock('PHPMentors\DomainCommons\DateTime\Clock');
+        $clock = $this->createMock('PHPMentors\DomainCommons\DateTime\Clock');
         $clock->method('now')->will($this->returnValue($currentDate));
         $ageRange = new AgeRange();
         $ageRange->setClock($clock);

--- a/tests/DateTime/DateTest.php
+++ b/tests/DateTime/DateTest.php
@@ -12,7 +12,9 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
-class DateTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DateTest extends TestCase
 {
     /**
      * @test

--- a/tests/DateTime/DateTimeTest.php
+++ b/tests/DateTime/DateTimeTest.php
@@ -12,7 +12,10 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
-class DateTimeTest extends \PHPUnit_Framework_TestCase
+use PHPMentors\DomainCommons\DateTime\Exception\UnsupportedCalculation;
+use PHPUnit\Framework\TestCase;
+
+class DateTimeTest extends TestCase
 {
     /**
      * @test
@@ -69,10 +72,11 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
      * @param string  $dateStr
      * @param int     $months
      * @dataProvider  addMonthsThrowsExceptionData
-     * @expectedException \PHPMentors\DomainCommons\DateTime\Exception\UnsupportedCalculation
      */
     public function addMonthsThrowsException($dateStr, $months)
     {
+        $this->expectException(UnsupportedCalculation::class);
+
         $date = new DateTime($dateStr);
 
         $date->addMonths($months);

--- a/tests/DateTime/HourMinTest.php
+++ b/tests/DateTime/HourMinTest.php
@@ -12,7 +12,9 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
-class HourMinTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class HourMinTest extends TestCase
 {
     /**
      * @test

--- a/tests/DateTime/MonthDayTest.php
+++ b/tests/DateTime/MonthDayTest.php
@@ -12,7 +12,9 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
-class MonthDayTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MonthDayTest extends TestCase
 {
     /**
      * @test

--- a/tests/DateTime/PeriodTraitTest.php
+++ b/tests/DateTime/PeriodTraitTest.php
@@ -12,6 +12,7 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
+use PHPUnit\Framework\TestCase;
 use PHPMentors\DomainCommons\DateTime\Period\DailyIteratableInterface;
 use PHPMentors\DomainCommons\DateTime\Period\DailyTrait;
 
@@ -26,7 +27,7 @@ class DailyPeriod extends Period implements DailyIteratableInterface
     }
 }
 
-class PeriodTraitTest extends \PHPUnit_Framework_TestCase
+class PeriodTraitTest extends TestCase
 {
     /**
      * @test

--- a/tests/DateTime/ThreeMonthlyTraitTest.php
+++ b/tests/DateTime/ThreeMonthlyTraitTest.php
@@ -12,6 +12,7 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
+use PHPUnit\Framework\TestCase;
 use PHPMentors\DomainCommons\DateTime\Period\MonthlyIteratableInterface;
 use PHPMentors\DomainCommons\DateTime\Period\ThreeMonthlyTrait;
 
@@ -38,7 +39,7 @@ class OneTerm extends Term
     public function getEnd(){return $this->end;}
 }
 
-class ThreeMonthlyTraitTest extends \PHPUnit_Framework_TestCase
+class ThreeMonthlyTraitTest extends TestCase
 {
     /**
      * @test

--- a/tests/DateTime/YearMonthTest.php
+++ b/tests/DateTime/YearMonthTest.php
@@ -12,7 +12,9 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
-class YearMonthTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class YearMonthTest extends TestCase
 {
     /**
      * @test

--- a/tests/DateTime/YearTest.php
+++ b/tests/DateTime/YearTest.php
@@ -12,7 +12,9 @@
 
 namespace PHPMentors\DomainCommons\DateTime;
 
-class YearTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class YearTest extends TestCase
 {
     /**
      * @test

--- a/tests/String/UniqueNameTest.php
+++ b/tests/String/UniqueNameTest.php
@@ -12,10 +12,12 @@
 
 namespace PHPMentors\DomainCommons\String;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @since Class available since Release 1.1.1
  */
-class UniqueNameTest extends \PHPUnit_Framework_TestCase
+class UniqueNameTest extends TestCase
 {
     public function test()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,3 @@
 <?php
 
-/** @var $loader \Composer\Autoload\ClassLoader */
-$loader = require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
To: @iteman ( Cc: @hidenorigoto )

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | The BSD 2-Clause License |
| Doc PR | no |

- Update the minimum supported `PHP version` from `5.5` to `7.2`
- Update tests (PHPUnit version from `4.6` to `8.3`)
- Update .travis.yml

## 気になっているところ

- PHP `7.1` は含めていません。含めるほうが良ければ修正したいと思います。
- PHP7以降の一般的な文法へのアップグレードや `CS` への対応は行っておりません。対応した方が良ければ変更したいと思います。

## 背景（変更を希望した理由）

- DateTime 系機能のみを単一の独立パッケージとして使うこともできるようにするPRを別途お送りする予定です。そのPRを作るにあたり、まずPHPサポートバージョンを整理する必要がありました。